### PR TITLE
[FEATURE] InitAdmin, UserDetails기능 추가

### DIFF
--- a/closet/src/main/java/com/codeit/closet/common/config/SecurityConfig.java
+++ b/closet/src/main/java/com/codeit/closet/common/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.codeit.closet.common.config;
 
+import com.codeit.closet.common.security.Http401UnauthorizedEntryPoint;
 import com.codeit.closet.common.security.Http403ForbiddenAccessDeniedHandler;
 import com.codeit.closet.common.security.LoginFailureHandler;
 import com.codeit.closet.common.security.SpaCsrfTokenRequestHandler;
@@ -35,7 +36,8 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http,
                                            LoginFailureHandler loginFailureHandler,
                                            DaoAuthenticationProvider daoAuthenticationProvider,
-                                           Http403ForbiddenAccessDeniedHandler forbiddenAccessDeniedHandler) throws Exception {
+                                           Http403ForbiddenAccessDeniedHandler forbiddenAccessDeniedHandler,
+                                           Http401UnauthorizedEntryPoint unauthorizedEntryPoint) throws Exception {
         http
                 .authenticationProvider(daoAuthenticationProvider)
                 // CSRF 사용용 설정
@@ -49,7 +51,7 @@ public class SecurityConfig {
                 )
 
                 .exceptionHandling(exception -> exception
-                        .authenticationEntryPoint(new Http403ForbiddenEntryPoint())
+                        .authenticationEntryPoint(unauthorizedEntryPoint)
                         .accessDeniedHandler(forbiddenAccessDeniedHandler))
                 // Cors 설정
                 .cors(Customizer.withDefaults())

--- a/closet/src/main/java/com/codeit/closet/common/config/SecurityConfig.java
+++ b/closet/src/main/java/com/codeit/closet/common/config/SecurityConfig.java
@@ -1,71 +1,104 @@
 package com.codeit.closet.common.config;
 
+import com.codeit.closet.common.security.Http403ForbiddenAccessDeniedHandler;
+import com.codeit.closet.common.security.LoginFailureHandler;
 import com.codeit.closet.common.security.SpaCsrfTokenRequestHandler;
-import java.util.List;
+import com.codeit.closet.module.user.entity.UserRole;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyAuthoritiesMapper;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.Http403ForbiddenEntryPoint;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
 public class SecurityConfig {
 
-  @Bean
-  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-    http
-        // CSRF 사용용 설정
-        .csrf(csrf -> csrf
-            .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
-            .csrfTokenRequestHandler(new SpaCsrfTokenRequestHandler()))
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http,
+                                           LoginFailureHandler loginFailureHandler,
+                                           DaoAuthenticationProvider daoAuthenticationProvider,
+                                           Http403ForbiddenAccessDeniedHandler forbiddenAccessDeniedHandler) throws Exception {
+        http
+                .authenticationProvider(daoAuthenticationProvider)
+                // CSRF 사용용 설정
+                .csrf(csrf -> csrf
+                        .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                        .csrfTokenRequestHandler(new SpaCsrfTokenRequestHandler()))
 
-        // 권한 범위 허용
-        .authorizeHttpRequests(auth -> auth
-            .anyRequest().permitAll()
-        )
+                // 권한 범위 허용
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll()
+                )
 
-        // Cors 설정
-        .cors(Customizer.withDefaults())
-        .httpBasic(Customizer.withDefaults());
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(new Http403ForbiddenEntryPoint())
+                        .accessDeniedHandler(forbiddenAccessDeniedHandler))
+                // Cors 설정
+                .cors(Customizer.withDefaults())
+                .httpBasic(Customizer.withDefaults());
 
-    return http.build();
-  }
+        return http.build();
+    }
 
-  @Bean
-  public PasswordEncoder passwordEncoder() {
-    return new BCryptPasswordEncoder();
-  }
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
 
-  @Bean
-  CorsConfigurationSource corsConfigurationSource() {
-    CorsConfiguration config = new CorsConfiguration();
+    @Bean
+    CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
 
-    config.setAllowedOrigins(List.of("http://localhost:3000"));
+        config.setAllowedOrigins(List.of("http://localhost:3000"));
 
-    config.setAllowedMethods(List.of(
-        "GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"
-    ));
+        config.setAllowedMethods(List.of(
+                "GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"
+        ));
 
-    config.setAllowedHeaders(List.of("*"));
-    config.setExposedHeaders(List.of("Authorization"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setExposedHeaders(List.of("Authorization"));
 
-    config.setAllowCredentials(true); // 🔥 쿠키 사용 시 필수
+        config.setAllowCredentials(true); // 🔥 쿠키 사용 시 필수
 
-    UrlBasedCorsConfigurationSource source =
-        new UrlBasedCorsConfigurationSource();
-    source.registerCorsConfiguration("/**", config);
+        UrlBasedCorsConfigurationSource source =
+                new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
 
-    return source;
-  }
+        return source;
+    }
 
+    @Bean
+    public RoleHierarchy roleHierarchy() {
+        return RoleHierarchyImpl.withDefaultRolePrefix()
+                .role(UserRole.ADMIN.name()).implies(UserRole.USER.name())
+                .build();
+    }
+
+    @Bean
+    public DaoAuthenticationProvider daoAuthenticationProvider(UserDetailsService userDetailsService,
+                                                               PasswordEncoder passwordEncoder,
+                                                               RoleHierarchy roleHierarchy) {
+        DaoAuthenticationProvider provider = new DaoAuthenticationProvider(userDetailsService);
+        provider.setPasswordEncoder(passwordEncoder);
+        provider.setAuthoritiesMapper(new RoleHierarchyAuthoritiesMapper(roleHierarchy));
+        return provider;
+    }
 }

--- a/closet/src/main/java/com/codeit/closet/common/exception/ErrorResponse.java
+++ b/closet/src/main/java/com/codeit/closet/common/exception/ErrorResponse.java
@@ -1,0 +1,24 @@
+package com.codeit.closet.common.exception;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ErrorResponse {
+
+    private final Instant timestamp;
+    private final String code;
+    private final String message;
+    private final Map<String, Object> details;
+    private final String exceptionType;
+    private final int status;
+
+    public ErrorResponse(Exception exception, int status) {
+        this(Instant.now(), exception.getClass().getSimpleName(), exception.getMessage(),
+                new HashMap<>(), exception.getClass().getSimpleName(), status);
+    }
+}

--- a/closet/src/main/java/com/codeit/closet/common/security/AdminUserInitializer.java
+++ b/closet/src/main/java/com/codeit/closet/common/security/AdminUserInitializer.java
@@ -1,0 +1,18 @@
+package com.codeit.closet.common.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AdminUserInitializer implements ApplicationRunner {
+
+  private final InitAdminService initService;
+
+  @Override
+  public void run(ApplicationArguments args) {
+    initService.initAdmin();        // 애플리케이션 실행 시 ADMIN 권한을 가진 어드민 계정이 초기화
+  }
+}

--- a/closet/src/main/java/com/codeit/closet/common/security/ClosetUserDetails.java
+++ b/closet/src/main/java/com/codeit/closet/common/security/ClosetUserDetails.java
@@ -1,0 +1,37 @@
+package com.codeit.closet.common.security;
+
+import com.codeit.closet.module.user.dto.user.UserDTO;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+@EqualsAndHashCode(of = "userDTO")
+public class ClosetUserDetails implements UserDetails {
+    private final UserDTO userDTO;
+    private final String password;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_" + userDTO.role().name()));
+    }
+
+    @Override // 로그인 식별자
+    public String getUsername() {
+        return userDTO.email();
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+}
+

--- a/closet/src/main/java/com/codeit/closet/common/security/ClosetUserDetailsService.java
+++ b/closet/src/main/java/com/codeit/closet/common/security/ClosetUserDetailsService.java
@@ -19,7 +19,7 @@ public class ClosetUserDetailsService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         User user = userRepository.findByEmail(email).orElseThrow(()
-                -> new UsernameNotFoundException("유저를 찾을 없습니다." + email));
+                -> new UsernameNotFoundException("유저를 찾을 수 없습니다." + email));
         return new ClosetUserDetails(userMapper.toUserDTO(user), user.getPassword());
     }
 }

--- a/closet/src/main/java/com/codeit/closet/common/security/ClosetUserDetailsService.java
+++ b/closet/src/main/java/com/codeit/closet/common/security/ClosetUserDetailsService.java
@@ -1,0 +1,25 @@
+package com.codeit.closet.common.security;
+
+import com.codeit.closet.module.user.entity.User;
+import com.codeit.closet.module.user.mapper.UserMapper;
+import com.codeit.closet.module.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ClosetUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+    private final UserMapper userMapper;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email).orElseThrow(()
+                -> new UsernameNotFoundException("유저를 찾을 없습니다." + email));
+        return new ClosetUserDetails(userMapper.toUserDTO(user), user.getPassword());
+    }
+}

--- a/closet/src/main/java/com/codeit/closet/common/security/Http401UnauthorizedEntryPoint.java
+++ b/closet/src/main/java/com/codeit/closet/common/security/Http401UnauthorizedEntryPoint.java
@@ -1,0 +1,30 @@
+package com.codeit.closet.common.security;
+
+import com.codeit.closet.common.exception.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class Http401UnauthorizedEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        ErrorResponse errorResponse = new ErrorResponse(authException,
+                HttpStatus.UNAUTHORIZED.value());
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/closet/src/main/java/com/codeit/closet/common/security/Http403ForbiddenAccessDeniedHandler.java
+++ b/closet/src/main/java/com/codeit/closet/common/security/Http403ForbiddenAccessDeniedHandler.java
@@ -1,0 +1,32 @@
+package com.codeit.closet.common.security;
+
+import com.codeit.closet.common.exception.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class Http403ForbiddenAccessDeniedHandler implements AccessDeniedHandler {
+
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public void handle(HttpServletRequest request, HttpServletResponse response,
+      AccessDeniedException accessDeniedException) throws IOException, ServletException {
+    response.setStatus(HttpServletResponse.SC_FORBIDDEN); // 403
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    ErrorResponse errorResponse = new ErrorResponse(accessDeniedException,
+        HttpStatus.FORBIDDEN.value());
+    response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+  }
+}

--- a/closet/src/main/java/com/codeit/closet/common/security/InitAdminService.java
+++ b/closet/src/main/java/com/codeit/closet/common/security/InitAdminService.java
@@ -1,0 +1,46 @@
+package com.codeit.closet.common.security;
+
+import com.codeit.closet.module.user.entity.User;
+import com.codeit.closet.module.user.entity.UserRole;
+import com.codeit.closet.module.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class InitAdminService {
+
+    @Value("${closet.admin.username}")
+    private String adminUsername;
+    @Value("${closet.admin.password}")
+    private String adminPassword;
+    @Value("${closet.admin.email}")
+    private String adminEmail;
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public void initAdmin() {
+        if (userRepository.existsByEmail(adminEmail) || userRepository.existsByName(adminUsername)) {
+            log.warn("이미 관리자가 존재합니다.");
+            return;
+        }
+
+        User admin = User.builder()
+                .name(adminUsername)
+                .email(adminEmail)
+                .password(passwordEncoder.encode(adminPassword))
+                .role(UserRole.ADMIN)
+                .build();
+
+        userRepository.save(admin);
+        log.info("관리자가 초기화되었습니다.");
+    }
+
+}

--- a/closet/src/main/java/com/codeit/closet/common/security/LoginFailureHandler.java
+++ b/closet/src/main/java/com/codeit/closet/common/security/LoginFailureHandler.java
@@ -1,0 +1,36 @@
+package com.codeit.closet.common.security;
+
+import com.codeit.closet.common.exception.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LoginFailureHandler implements AuthenticationFailureHandler {
+
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public void onAuthenticationFailure(HttpServletRequest request,
+      HttpServletResponse response,
+      AuthenticationException exception) throws IOException, ServletException {
+    log.error("Authentication Failed : {}", exception.getMessage());
+
+    // 응답값 생성
+    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    ErrorResponse errorResponse = new ErrorResponse(exception, HttpServletResponse.SC_UNAUTHORIZED);
+    response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+  }
+}

--- a/closet/src/main/java/com/codeit/closet/module/user/entity/User.java
+++ b/closet/src/main/java/com/codeit/closet/module/user/entity/User.java
@@ -48,7 +48,7 @@ public class User {
     private Instant birthDate;
 
     @Column(name = "temperature_sensitivity", nullable = false)
-    private Integer temperatureSensitivity = 3;
+    private Integer temperatureSensitivity;
 
     @Column(name = "temp_password")
     private String tempPassword;
@@ -67,4 +67,10 @@ public class User {
     @Column(name = "updated_at")
     private Instant updatedAt;
 
+    @PrePersist
+    public void initFileUrl() {
+        if (temperatureSensitivity == null) {
+            this.temperatureSensitivity = 3;
+        }
+    }
 }

--- a/closet/src/main/java/com/codeit/closet/module/user/entity/User.java
+++ b/closet/src/main/java/com/codeit/closet/module/user/entity/User.java
@@ -68,7 +68,7 @@ public class User {
     private Instant updatedAt;
 
     @PrePersist
-    public void initFileUrl() {
+    public void initTemperatureSensitivity() {
         if (temperatureSensitivity == null) {
             this.temperatureSensitivity = 3;
         }

--- a/closet/src/main/java/com/codeit/closet/module/user/repository/UserRepository.java
+++ b/closet/src/main/java/com/codeit/closet/module/user/repository/UserRepository.java
@@ -3,7 +3,13 @@ package com.codeit.closet.module.user.repository;
 import com.codeit.closet.module.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface UserRepository extends JpaRepository<User, UUID> {
+    boolean existsByEmail(String email);
+
+    boolean existsByName(String name);
+
+    Optional<User> findByEmail(String email);
 }

--- a/closet/src/main/resources/application.yml
+++ b/closet/src/main/resources/application.yml
@@ -22,3 +22,7 @@ closet:
     type: ${STORAGE_TYPE:local}
     local:
       root-path: ${STORAGE_LOCAL_ROOT_PATH:storage}
+  admin:
+    username: ${ADMIN_USERNAME:admin}
+    email: ${ADMIN_EMAIL:admin@admin.com}
+    password: ${ADMIN_PASSWORD:admin}


### PR DESCRIPTION
## 📎 Issue 번호
- closed #33 

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 📋 작업 내용 상세
- [x] 어드민 초기화 및 어드민 생성 추가 
- [x] 유저 상태정보 저장할 수있는 ClosetUserDetails 추가
- [x] 임의의 예외처리 문 추가 401, 403

## 📄 작업 내용 요약

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 강화된 보안 구성(인증·인가 흐름, CORS/CSRF, 역할 계층) 적용
  * 관리자 계정 자동 초기화 기능 추가
  * 표준화된 JSON 오류 응답 및 401/403 전용 응답 처리기 추가

* **개선사항**
  * 로그인 실패·접근 거부 응답 품질 향상
  * 사용자 조회·존재 확인 API 확장
  * 사용자 엔티티의 초기값 처리 시점 개선 (영속화 전 설정)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->