### PR TITLE
[FEATURE] User 도메인 비즈니스 로직 추가

### DIFF
--- a/closet/build.gradle
+++ b/closet/build.gradle
@@ -25,7 +25,7 @@ repositories {
 }
 
 ext {
-    mapstructVersion = "1.5.5.Final"
+    mapstructVersion = "1.6.3"
 }
 
 dependencies {
@@ -70,6 +70,7 @@ dependencies {
      * ========================= */
     implementation "org.mapstruct:mapstruct:${mapstructVersion}"
     annotationProcessor "org.mapstruct:mapstruct-processor:${mapstructVersion}"
+    annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
 
     /* =========================
      * Lombok

--- a/closet/src/main/java/com/codeit/closet/common/util/converter/FlexibleInstantDeserializer.java
+++ b/closet/src/main/java/com/codeit/closet/common/util/converter/FlexibleInstantDeserializer.java
@@ -1,0 +1,52 @@
+package com.codeit.closet.common.util.converter;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+
+import java.io.IOException;
+import java.time.*;
+import java.time.format.DateTimeFormatter;
+
+public class FlexibleInstantDeserializer extends JsonDeserializer<Instant> {
+
+    @Override
+    public Instant deserialize(JsonParser p, DeserializationContext ctxt)
+            throws IOException {
+
+        String value = p.getText();
+
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+
+        // Instant (Z, +09:00)
+        try {
+            return Instant.parse(value);
+        } catch (Exception ignored) {}
+
+        // LocalDateTime
+        try {
+            return LocalDateTime
+                    .parse(value, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+                    .toInstant(ZoneOffset.UTC);
+        } catch (Exception ignored) {}
+
+        // LocalDate
+        try {
+            return LocalDate
+                    .parse(value)
+                    .atStartOfDay(ZoneOffset.UTC)
+                    .toInstant();
+        } catch (Exception ignored) {}
+
+        throw new InvalidFormatException(
+                p,
+                "Invalid date format for birthDate. " +
+                "Supported: yyyy-MM-dd, yyyy-MM-ddTHH:mm:ss, yyyy-MM-ddTHH:mm:ssZ",
+                value,
+                Instant.class
+        );
+    }
+}

--- a/closet/src/main/java/com/codeit/closet/common/util/converter/InstantToDateSerializer.java
+++ b/closet/src/main/java/com/codeit/closet/common/util/converter/InstantToDateSerializer.java
@@ -1,0 +1,38 @@
+package com.codeit.closet.common.util.converter;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+public class InstantToDateSerializer extends JsonSerializer<Instant> {
+
+    private static final DateTimeFormatter FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    private static final ZoneId ZONE_ID = ZoneId.of("Asia/Seoul");
+
+    @Override
+    public void serialize(
+            Instant value,
+            JsonGenerator gen,
+            SerializerProvider serializers
+    ) throws IOException {
+
+        if (value == null) {
+            gen.writeNull();
+            return;
+        }
+
+        String formatted =
+                value.atZone(ZONE_ID)
+                     .toLocalDate()
+                     .format(FORMATTER);
+
+        gen.writeString(formatted);
+    }
+}

--- a/closet/src/main/java/com/codeit/closet/module/user/controller/UserController.java
+++ b/closet/src/main/java/com/codeit/closet/module/user/controller/UserController.java
@@ -2,73 +2,91 @@ package com.codeit.closet.module.user.controller;
 
 import com.codeit.closet.module.user.dto.profile.ProfileDTO;
 import com.codeit.closet.module.user.dto.profile.ProfileUpdateRequest;
-import com.codeit.closet.module.user.dto.user.*;
+import com.codeit.closet.module.user.dto.user.ChangePasswordRequest;
+import com.codeit.closet.module.user.dto.user.UserCreateRequest;
+import com.codeit.closet.module.user.dto.user.UserDTO;
+import com.codeit.closet.module.user.dto.user.UserDTOCursorResponse;
+import com.codeit.closet.module.user.dto.user.UserLockUpdateRequest;
+import com.codeit.closet.module.user.dto.user.UserRoleUpdateRequest;
 import com.codeit.closet.module.user.service.UserService;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.UUID;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
 public class UserController {
-    private final UserService userService;
 
-    @PostMapping
-    public ResponseEntity<UserDTO> createUser(@RequestBody UserCreateRequest request) {
-        UserDTO result = userService.createUser(request);
-        return ResponseEntity.status(HttpStatus.OK).body(result);
-    }
+  private final UserService userService;
 
-    @GetMapping
-    public ResponseEntity<UserDTOCursorResponse> getUsers(
-            @RequestParam(required = false) String cursor,
-            @RequestParam(required = false) UUID idAfter,
-            @RequestParam Integer limit,
-            @RequestParam String sortBy,
-            @RequestParam String sortDirection,
-            @RequestParam(required = false) String emailLike,
-            @RequestParam(required = false) String roleEqual,
-            @RequestParam(required = false) Boolean locked
-    ) {
-        UserDTOCursorResponse results = userService.findUsers(cursor, idAfter, limit, sortBy, sortDirection, emailLike, roleEqual, locked);
-        return ResponseEntity.status(HttpStatus.OK).body(results);
-    }
+  @PostMapping
+  public ResponseEntity<UserDTO> createUser(@RequestBody UserCreateRequest request) {
+    UserDTO result = userService.createUser(request);
+    return ResponseEntity.status(HttpStatus.OK).body(result);
+  }
 
-    @PatchMapping("/{userId}/role")
-    public ResponseEntity<UserDTO> updateUserRole(@PathVariable UUID userId,
-                                                  @RequestBody UserRoleUpdateRequest request) {
-        UserDTO result = userService.updateUserRole(userId, request);
-        return ResponseEntity.status(HttpStatus.OK).body(result);
-    }
+  @GetMapping
+  public ResponseEntity<UserDTOCursorResponse> getUsers(
+      @RequestParam(required = false) String cursor,
+      @RequestParam(required = false) UUID idAfter,
+      @RequestParam Integer limit,
+      @RequestParam String sortBy,
+      @RequestParam String sortDirection,
+      @RequestParam(required = false) String emailLike,
+      @RequestParam(required = false) String roleEqual,
+      @RequestParam(required = false) Boolean locked
+  ) {
+    UserDTOCursorResponse results = userService.findUsers(cursor, idAfter, limit, sortBy,
+        sortDirection, emailLike, roleEqual, locked);
+    return ResponseEntity.status(HttpStatus.OK).body(results);
+  }
 
-    @GetMapping("/{userId}/profiles")
-    public ResponseEntity<ProfileDTO> getUserProfile(@PathVariable UUID userId) {
-        ProfileDTO result = userService.findUserProfile(userId);
-        return ResponseEntity.status(HttpStatus.OK).body(result);
-    }
+  @PatchMapping("/{userId}/role")
+  public ResponseEntity<UserDTO> updateUserRole(@PathVariable UUID userId,
+      @RequestBody UserRoleUpdateRequest request) {
+    UserDTO result = userService.updateUserRole(userId, request);
+    return ResponseEntity.status(HttpStatus.OK).body(result);
+  }
 
-    @PatchMapping("/{userId}/profiles")
-    public ResponseEntity<ProfileDTO> updateUserProfile(@PathVariable UUID userId,
-                                                        @RequestBody ProfileUpdateRequest request) { // 이미지도 가능하게
-        ProfileDTO result = userService.updateUserProfile(userId, request);
-        return ResponseEntity.status(HttpStatus.OK).body(result);
-    }
+  @GetMapping("/{userId}/profiles")
+  public ResponseEntity<ProfileDTO> getUserProfile(@PathVariable UUID userId) {
+    ProfileDTO result = userService.findUserProfile(userId);
+    return ResponseEntity.status(HttpStatus.OK).body(result);
+  }
 
-    @PatchMapping("/{userId}/password")
-    public ResponseEntity<Void> updateUserPassword(@PathVariable UUID userId,
-                                                   @RequestBody ChangePasswordRequest request) {
-        userService.updateUserPassword(userId, request);
-        return ResponseEntity.status(HttpStatus.OK).build();
-    }
+  @PatchMapping(value = "/{userId}/profiles", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public ResponseEntity<ProfileDTO> updateUserProfile(@PathVariable UUID userId,
+      @RequestPart ProfileUpdateRequest request,
+      @RequestPart(value = "image", required = false) MultipartFile multipartFile){
 
-    @PatchMapping("/{userId}/lock")
-    public ResponseEntity<UserDTO> updateUserLock(@PathVariable UUID userId,
-                                                  @RequestBody UserLockUpdateRequest request) {
-        UserDTO result = userService.updateUserLock(userId, request);
-        return ResponseEntity.status(HttpStatus.OK).body(result);
-    }
+    ProfileDTO result = userService.updateUserProfile(userId, request, multipartFile);
+    return ResponseEntity.status(HttpStatus.OK).body(result);
+  }
+
+  @PatchMapping("/{userId}/password")
+  public ResponseEntity<Void> updateUserPassword(@PathVariable UUID userId,
+      @RequestBody ChangePasswordRequest request) {
+    userService.updateUserPassword(userId, request);
+    return ResponseEntity.status(HttpStatus.OK).build();
+  }
+
+  @PatchMapping("/{userId}/lock")
+  public ResponseEntity<UserDTO> updateUserLock(@PathVariable UUID userId,
+      @RequestBody UserLockUpdateRequest request) {
+    UserDTO result = userService.updateUserLock(userId, request);
+    return ResponseEntity.status(HttpStatus.OK).body(result);
+  }
 }

--- a/closet/src/main/java/com/codeit/closet/module/user/dto/profile/ProfileDTO.java
+++ b/closet/src/main/java/com/codeit/closet/module/user/dto/profile/ProfileDTO.java
@@ -1,7 +1,9 @@
 package com.codeit.closet.module.user.dto.profile;
 
+import com.codeit.closet.common.util.converter.InstantToDateSerializer;
 import com.codeit.closet.module.user.entity.UserGender;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.time.Instant;
 import java.util.UUID;
 
@@ -9,7 +11,10 @@ public record ProfileDTO(
         UUID userId,
         String name,
         UserGender gender,
+
+        @JsonSerialize(using = InstantToDateSerializer.class)
         Instant birthDate,
+
         // LocationDto location,
         Integer temperatureSensitivity,
         String profileImageUrl

--- a/closet/src/main/java/com/codeit/closet/module/user/dto/profile/ProfileUpdateRequest.java
+++ b/closet/src/main/java/com/codeit/closet/module/user/dto/profile/ProfileUpdateRequest.java
@@ -1,11 +1,16 @@
 package com.codeit.closet.module.user.dto.profile;
 
+import com.codeit.closet.common.util.converter.FlexibleInstantDeserializer;
 import com.codeit.closet.module.user.entity.UserGender;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.time.Instant;
 
 public record ProfileUpdateRequest(
         String name,
         UserGender gender,
-        String birthDate,
+
+        @JsonDeserialize(using = FlexibleInstantDeserializer.class)
+        Instant birthDate,
         //LocationDto location,              // 위치 정보 객체
         Integer temperatureSensitivity
 ) {

--- a/closet/src/main/java/com/codeit/closet/module/user/entity/User.java
+++ b/closet/src/main/java/com/codeit/closet/module/user/entity/User.java
@@ -1,12 +1,29 @@
 package com.codeit.closet.module.user.entity;
 
-import jakarta.persistence.*;
-import lombok.*;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
-
+import com.codeit.closet.module.binarycontent.entity.BinaryContent;
+import com.codeit.closet.module.user.dto.profile.ProfileUpdateRequest;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
 import java.time.Instant;
 import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 @Entity
 @Table(name = "users")
@@ -20,8 +37,9 @@ public class User {
     private UUID id;
 
     // binaryContent 생성 후 연동할꺼임.
-    @Column(name = "binary_content_id")
-    private UUID binaryContentId;
+    @OneToOne(orphanRemoval = true, fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @JoinColumn(name = "binary_content_id")
+    private BinaryContent binaryContent;
 
     // weather 추가되면 연동할꺼임.
     @Column(name = "weather_id")
@@ -68,9 +86,51 @@ public class User {
     private Instant updatedAt;
 
     @PrePersist
-    public void initTemperatureSensitivity() {
+    public void initUserDefinition() {
         if (temperatureSensitivity == null) {
             this.temperatureSensitivity = 3;
         }
+
+        if (role == null) {
+            this.role = UserRole.USER;
+        }
+    }
+
+    public void updateRole(UserRole role) {
+        if(role != null) {
+            this.role = role;
+        }
+    }
+
+    public void updateLocked(Boolean locked) {
+        if(locked != null) {
+            this.locked = locked;
+        }
+    }
+
+    public void updateProfile(ProfileUpdateRequest request, BinaryContent binaryContent) {
+        if (binaryContent != null){
+            this.binaryContent = binaryContent;
+        }
+
+        if (request.name() != null) {
+            this.name = request.name();
+        }
+
+        if (request.birthDate() != null) {
+            this.birthDate = request.birthDate();
+        }
+
+        if (request.temperatureSensitivity() != null) {
+            this.temperatureSensitivity = request.temperatureSensitivity();
+        }
+
+        if (request.gender() != null) {
+            this.gender = request.gender();
+        }
+    }
+
+    public void changePassword(String encodedPassword) {
+        this.password = encodedPassword;
     }
 }

--- a/closet/src/main/java/com/codeit/closet/module/user/entity/User.java
+++ b/closet/src/main/java/com/codeit/closet/module/user/entity/User.java
@@ -1,7 +1,6 @@
 package com.codeit.closet.module.user.entity;
 
 import com.codeit.closet.module.binarycontent.entity.BinaryContent;
-import com.codeit.closet.module.user.dto.profile.ProfileUpdateRequest;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -32,105 +31,107 @@ import org.hibernate.annotations.UpdateTimestamp;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class User {
-    @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    private UUID id;
 
-    // binaryContent 생성 후 연동할꺼임.
-    @OneToOne(orphanRemoval = true, fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
-    @JoinColumn(name = "binary_content_id")
-    private BinaryContent binaryContent;
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private UUID id;
 
-    // weather 추가되면 연동할꺼임.
-    @Column(name = "weather_id")
-    private UUID weatherId;
+  // binaryContent 생성 후 연동할꺼임.
+  @OneToOne(orphanRemoval = true, fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+  @JoinColumn(name = "binary_content_id")
+  private BinaryContent binaryContent;
 
-    @Column(length = 50, nullable = false)
-    private String name;
+  // weather 추가되면 연동할꺼임.
+  @Column(name = "weather_id")
+  private UUID weatherId;
 
-    @Column(length = 120, nullable = false, unique = true)
-    private String email;
+  @Column(length = 50, nullable = false)
+  private String name;
 
-    @Column(nullable = false)
-    private String password;
+  @Column(length = 120, nullable = false, unique = true)
+  private String email;
 
-    @Enumerated(EnumType.STRING)
-    @Column(length = 10)
-    private UserGender gender;
+  @Column(nullable = false)
+  private String password;
 
-    @Enumerated(EnumType.STRING)
-    @Column(length = 10, nullable = false)
-    private UserRole role;
+  @Enumerated(EnumType.STRING)
+  @Column(length = 10)
+  private UserGender gender;
 
-    @Column(name = "birth")
-    private Instant birthDate;
+  @Enumerated(EnumType.STRING)
+  @Column(length = 10, nullable = false)
+  private UserRole role;
 
-    @Column(name = "temperature_sensitivity", nullable = false)
-    private Integer temperatureSensitivity;
+  @Column(name = "birth")
+  private Instant birthDate;
 
-    @Column(name = "temp_password")
-    private String tempPassword;
+  @Column(name = "temperature_sensitivity", nullable = false)
+  private Integer temperatureSensitivity;
 
-    @Column(name = "temp_password_expired_at")
-    private Instant tempPasswordExpiredAt;
+  @Column(name = "temp_password")
+  private String tempPassword;
 
-    @Column
-    private Boolean locked;
+  @Column(name = "temp_password_expired_at")
+  private Instant tempPasswordExpiredAt;
 
-    @CreationTimestamp
-    @Column(name = "created_at", updatable = false, nullable = false)
-    private Instant createdAt;
+  @Column
+  private Boolean locked;
 
-    @UpdateTimestamp
-    @Column(name = "updated_at")
-    private Instant updatedAt;
+  @CreationTimestamp
+  @Column(name = "created_at", updatable = false, nullable = false)
+  private Instant createdAt;
 
-    @PrePersist
-    public void initUserDefinition() {
-        if (temperatureSensitivity == null) {
-            this.temperatureSensitivity = 3;
-        }
+  @UpdateTimestamp
+  @Column(name = "updated_at")
+  private Instant updatedAt;
 
-        if (role == null) {
-            this.role = UserRole.USER;
-        }
+  @PrePersist
+  public void initUserDefinition() {
+    if (temperatureSensitivity == null) {
+      this.temperatureSensitivity = 3;
     }
 
-    public void updateRole(UserRole role) {
-        if(role != null) {
-            this.role = role;
-        }
+    if (role == null) {
+      this.role = UserRole.USER;
+    }
+  }
+
+  public void updateRole(UserRole role) {
+    if (role != null) {
+      this.role = role;
+    }
+  }
+
+  public void updateLocked(Boolean locked) {
+    if (locked != null) {
+      this.locked = locked;
+    }
+  }
+
+  public void updateProfile(String name, Instant birthDate, Integer temperatureSensitivity,
+      UserGender gender, BinaryContent binaryContent) {
+    if (binaryContent != null) {
+      this.binaryContent = binaryContent;
     }
 
-    public void updateLocked(Boolean locked) {
-        if(locked != null) {
-            this.locked = locked;
-        }
+    if (name != null) {
+      this.name = name;
     }
 
-    public void updateProfile(ProfileUpdateRequest request, BinaryContent binaryContent) {
-        if (binaryContent != null){
-            this.binaryContent = binaryContent;
-        }
-
-        if (request.name() != null) {
-            this.name = request.name();
-        }
-
-        if (request.birthDate() != null) {
-            this.birthDate = request.birthDate();
-        }
-
-        if (request.temperatureSensitivity() != null) {
-            this.temperatureSensitivity = request.temperatureSensitivity();
-        }
-
-        if (request.gender() != null) {
-            this.gender = request.gender();
-        }
+    if (birthDate != null) {
+      this.birthDate = birthDate;
     }
 
-    public void changePassword(String encodedPassword) {
-        this.password = encodedPassword;
+    if (temperatureSensitivity != null) {
+      this.temperatureSensitivity = temperatureSensitivity;
     }
+
+    if (gender != null) {
+      this.gender = gender;
+    }
+  }
+
+  public void changePassword(String encodedPassword) {
+    this.password = encodedPassword;
+  }
 }

--- a/closet/src/main/java/com/codeit/closet/module/user/mapper/UserMapper.java
+++ b/closet/src/main/java/com/codeit/closet/module/user/mapper/UserMapper.java
@@ -4,12 +4,16 @@ import com.codeit.closet.module.user.dto.profile.ProfileDTO;
 import com.codeit.closet.module.user.dto.user.UserDTO;
 import com.codeit.closet.module.user.entity.User;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface UserMapper {
 
+    @Mapping(target = "role", source = "role")
     UserDTO toUserDTO(User user);
 
     // 차후에 LocationDTO랑 맵핑 해야함.
+    @Mapping(target = "profileImageUrl", source = "binaryContent.fileUrl")
+    @Mapping(target = "userId", source = "id")
     ProfileDTO toProfileDTO(User user);
 }

--- a/closet/src/main/java/com/codeit/closet/module/user/service/UserService.java
+++ b/closet/src/main/java/com/codeit/closet/module/user/service/UserService.java
@@ -5,6 +5,7 @@ import com.codeit.closet.module.user.dto.profile.ProfileUpdateRequest;
 import com.codeit.closet.module.user.dto.user.*;
 
 import java.util.UUID;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface UserService {
     UserDTO createUser(UserCreateRequest request);
@@ -22,7 +23,7 @@ public interface UserService {
 
     ProfileDTO findUserProfile(UUID userId);
 
-    ProfileDTO updateUserProfile(UUID userId, ProfileUpdateRequest request);
+    ProfileDTO updateUserProfile(UUID userId, ProfileUpdateRequest request, MultipartFile multipartFile);
 
     void updateUserPassword(UUID userId, ChangePasswordRequest request);
 

--- a/closet/src/main/java/com/codeit/closet/module/user/service/impl/BasicUserService.java
+++ b/closet/src/main/java/com/codeit/closet/module/user/service/impl/BasicUserService.java
@@ -1,69 +1,123 @@
 package com.codeit.closet.module.user.service.impl;
 
+import com.codeit.closet.module.binarycontent.entity.BinaryContent;
+import com.codeit.closet.module.binarycontent.service.BinaryContentService;
 import com.codeit.closet.module.user.dto.profile.ProfileDTO;
 import com.codeit.closet.module.user.dto.profile.ProfileUpdateRequest;
 import com.codeit.closet.module.user.dto.user.*;
+import com.codeit.closet.module.user.entity.User;
 import com.codeit.closet.module.user.mapper.UserMapper;
 import com.codeit.closet.module.user.repository.UserRepository;
 import com.codeit.closet.module.user.service.UserService;
+import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
 public class BasicUserService implements UserService {
-    private final UserRepository userRepository;
-    private final UserMapper userMapper;
 
-    @Override
-    @Transactional
-    public UserDTO createUser(UserCreateRequest request) {
-        return null;
+  private final UserRepository userRepository;
+  private final UserMapper userMapper;
+  private final PasswordEncoder passwordEncoder;
+  private final BinaryContentService binaryContentService;
+
+  @Override
+  @Transactional
+  public UserDTO createUser(UserCreateRequest request) {
+    if (userRepository.existsByEmail(request.email())) {
+      throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
     }
 
-    @Override
-    @Transactional(readOnly = true)
-    public UserDTOCursorResponse findUsers(String cursor,
-                                           UUID idAfter,
-                                           Integer limit,
-                                           String sortBy,
-                                           String sortDirection,
-                                           String emailLike,
-                                           String roleEqual,
-                                           Boolean locked) {
-        return null;
+    User user = User.builder()
+        .name(request.name())
+        .email(request.email())
+        .password(passwordEncoder.encode(request.password()))
+        .build();
+
+    User save = userRepository.save(user);
+
+    return userMapper.toUserDTO(save);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public UserDTOCursorResponse findUsers(String cursor,
+      UUID idAfter,
+      Integer limit,
+      String sortBy,
+      String sortDirection,
+      String emailLike,
+      String roleEqual,
+      Boolean locked) {
+    return null;
+  }
+
+  // Admin만 가능하게 바꿔야함.
+  @Override
+  @Transactional
+  public UserDTO updateUserRole(UUID userId, UserRoleUpdateRequest request) {
+    User user = userRepository.findById(userId).orElseThrow(
+        () -> new NoSuchElementException("존재하지 않는 회원입니다."));
+
+    user.updateRole(request.role());
+
+    return userMapper.toUserDTO(user);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public ProfileDTO findUserProfile(UUID userId) {
+    User user = userRepository.findById(userId).orElseThrow(
+        () -> new NoSuchElementException("존재하지 않는 회원입니다."));
+
+    return userMapper.toProfileDTO(user);
+  }
+
+  @Override
+  @Transactional
+  public ProfileDTO updateUserProfile(UUID userId, ProfileUpdateRequest request,
+      MultipartFile multipartFile) {
+    User user = userRepository.findById(userId).orElseThrow(
+        () -> new NoSuchElementException("존재하지 않는 회원입니다."));
+
+    BinaryContent binaryContent = null;
+    if (multipartFile != null) {
+      binaryContent = binaryContentService.createBinaryContent(multipartFile);
     }
 
-    @Override
-    @Transactional
-    public UserDTO updateUserRole(UUID userId, UserRoleUpdateRequest request) {
-        return null;
-    }
+    // 차후에 Location 처리 넣어야함.
 
-    @Override
-    @Transactional(readOnly = true)
-    public ProfileDTO findUserProfile(UUID userId) {
-        return null;
-    }
+    user.updateProfile(request, binaryContent);
 
-    @Override
-    @Transactional
-    public ProfileDTO updateUserProfile(UUID userId, ProfileUpdateRequest request) {
-        return null;
-    }
+    return userMapper.toProfileDTO(user);
+  }
 
-    @Override
-    @Transactional
-    public void updateUserPassword(UUID userId, ChangePasswordRequest request) {
+  @Override
+  @Transactional
+  public void updateUserPassword(UUID userId, ChangePasswordRequest request) {
+    User user = userRepository.findById(userId).orElseThrow(
+        () -> new NoSuchElementException("존재하지 않는 회원입니다."));
 
-    }
+    String encodedNewPassword = passwordEncoder.encode(request.password());
 
-    @Override
-    @Transactional
-    public UserDTO updateUserLock(UUID userId, UserLockUpdateRequest request) {
-        return null;
-    }
+    user.changePassword(encodedNewPassword);
+  }
+
+  // Admin만 처리
+  @Override
+  @Transactional
+  public UserDTO updateUserLock(UUID userId, UserLockUpdateRequest request) {
+    User user = userRepository.findById(userId).orElseThrow(
+        () -> new NoSuchElementException("존재하지 않는 회원입니다."));
+
+    user.updateLocked(request.locked());
+
+    return userMapper.toUserDTO(user);
+  }
 }

--- a/closet/src/main/java/com/codeit/closet/module/user/service/impl/BasicUserService.java
+++ b/closet/src/main/java/com/codeit/closet/module/user/service/impl/BasicUserService.java
@@ -4,18 +4,23 @@ import com.codeit.closet.module.binarycontent.entity.BinaryContent;
 import com.codeit.closet.module.binarycontent.service.BinaryContentService;
 import com.codeit.closet.module.user.dto.profile.ProfileDTO;
 import com.codeit.closet.module.user.dto.profile.ProfileUpdateRequest;
-import com.codeit.closet.module.user.dto.user.*;
+import com.codeit.closet.module.user.dto.user.ChangePasswordRequest;
+import com.codeit.closet.module.user.dto.user.UserCreateRequest;
+import com.codeit.closet.module.user.dto.user.UserDTO;
+import com.codeit.closet.module.user.dto.user.UserDTOCursorResponse;
+import com.codeit.closet.module.user.dto.user.UserLockUpdateRequest;
+import com.codeit.closet.module.user.dto.user.UserRoleUpdateRequest;
 import com.codeit.closet.module.user.entity.User;
 import com.codeit.closet.module.user.mapper.UserMapper;
 import com.codeit.closet.module.user.repository.UserRepository;
 import com.codeit.closet.module.user.service.UserService;
 import java.util.NoSuchElementException;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.UUID;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
@@ -58,7 +63,7 @@ public class BasicUserService implements UserService {
     return null;
   }
 
-  // Admin만 가능하게 바꿔야함.
+  @PreAuthorize("hasRole('ADMIN')")
   @Override
   @Transactional
   public UserDTO updateUserRole(UUID userId, UserRoleUpdateRequest request) {
@@ -93,11 +98,13 @@ public class BasicUserService implements UserService {
 
     // 차후에 Location 처리 넣어야함.
 
-    user.updateProfile(request, binaryContent);
+    user.updateProfile(request.name(), request.birthDate(),
+        request.temperatureSensitivity(), request.gender(), binaryContent);
 
     return userMapper.toProfileDTO(user);
   }
 
+  // 이메일 인증을 통한 비밀번호 리셋용 (별도 검증 로직 추가 예정)
   @Override
   @Transactional
   public void updateUserPassword(UUID userId, ChangePasswordRequest request) {
@@ -109,7 +116,8 @@ public class BasicUserService implements UserService {
     user.changePassword(encodedNewPassword);
   }
 
-  // Admin만 처리
+
+  @PreAuthorize("hasRole('ADMIN')")
   @Override
   @Transactional
   public UserDTO updateUserLock(UUID userId, UserLockUpdateRequest request) {


### PR DESCRIPTION
## 📎 Issue 번호
- closed #47 

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 📋 작업 내용 상세
- [x] User 도메인에 대한 생성, 조회, 프로필·권한·잠금·비밀번호 수정 기능을 JPA Dirty Checking 기반으로 구현하고, 프로필 이미지 업로드는 BinaryContent와 연동해 처리함
- [x] Instant용 직렬화, 역직렬화 추가 Front에서 yyyy-MM-dd 만 받아서 바꿧습니다.
- [x] lombok + MapStruct mapping 추가
- [x] 페이지네이션은 따로 구현할 예정, updatePassword랑, updateRole은 테스트는 안해봤습니다.
## 📄 작업 내용 요약

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 사용자 목록 조회(페이징·필터) 및 역할 변경, 프로필 조회/수정(이미지 업로드 포함), 비밀번호 변경, 계정 잠금/해제 API 추가

* **Improvements**
  * 입력용 날짜 형식 유연성 추가(여러 포맷 허용)
  * 프로필의 생년월일 응답 포맷 일관성 개선 (지역 기준 날짜 문자열로 직렬화)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->