### PR TITLE
[FEATURE] DM 저장 로직 구현

### DIFF
--- a/closet/src/main/java/com/codeit/closet/module/dm/controller/DirectMessageRestController.java
+++ b/closet/src/main/java/com/codeit/closet/module/dm/controller/DirectMessageRestController.java
@@ -1,14 +1,18 @@
 package com.codeit.closet.module.dm.controller;
 
+import com.codeit.closet.module.dm.dto.DirectMessageDTO;
 import com.codeit.closet.module.dm.dto.DirectMessageDTOCursorResponse;
+import com.codeit.closet.module.dm.dto.DirectMessageSaveRequest;
 import com.codeit.closet.module.dm.service.DirectMessageService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/direct-messages")
 @RequiredArgsConstructor
@@ -16,20 +20,18 @@ public class DirectMessageRestController {
 
     private final DirectMessageService directMessageService;
 
-    /*
-    ws 쪽에서 [DM 저장 api] 호출 예정
-    ws는 실시간 채팅만, api 쪽은 저장 및 조회로 기능 분리
-    */
-
     // DM 저장
     @PostMapping
-    public DirectMessageDTOCursorResponse createDirectMessage(
-            @AuthenticationPrincipal Jwt jwt,
-            @RequestParam UUID receiverId,
-            @RequestParam String content
-    ) {
-        UUID senderId = jwt.getClaim("userId");
-        return directMessageService.createDirectMessage(senderId, receiverId, content);
+    public DirectMessageDTO createDirectMessage(
+            @RequestBody DirectMessageSaveRequest directMessageSaveRequest
+            ) {
+//        UUID senderId = jwt.getClaim("userId"); senderId는 jwt로 분리 예정
+        log.info("[Controller] DM 저장 api 호출");
+        return directMessageService.create(
+                directMessageSaveRequest.senderId(),
+                directMessageSaveRequest.receiverId(),
+                directMessageSaveRequest.content()
+        );
     }
 
     // 이전 DM 내역 조회
@@ -42,6 +44,6 @@ public class DirectMessageRestController {
             @RequestParam int limit
     ) {
         UUID myUserId = jwt.getClaim("userId");
-        return directMessageService.getDirectMessages(myUserId, userId, cursor, idAfter, limit);
+        return directMessageService.findDirectMessages(myUserId, userId, cursor, idAfter, limit);
     }
 }

--- a/closet/src/main/java/com/codeit/closet/module/dm/controller/DirectMessageRestController.java
+++ b/closet/src/main/java/com/codeit/closet/module/dm/controller/DirectMessageRestController.java
@@ -23,6 +23,7 @@ public class DirectMessageRestController {
     // DM 저장
     @PostMapping
     public DirectMessageDTO createDirectMessage(
+//            @AuthenticationPrincipal Jwt jwt,
             @RequestBody DirectMessageSaveRequest directMessageSaveRequest
             ) {
 //        UUID senderId = jwt.getClaim("userId"); senderId는 jwt로 분리 예정

--- a/closet/src/main/java/com/codeit/closet/module/dm/dto/DirectMessageSaveRequest.java
+++ b/closet/src/main/java/com/codeit/closet/module/dm/dto/DirectMessageSaveRequest.java
@@ -1,0 +1,10 @@
+package com.codeit.closet.module.dm.dto;
+
+import java.util.UUID;
+
+// ws 서버에서 보냄
+public record DirectMessageSaveRequest(
+        UUID receiverId,
+        UUID senderId,
+        String content
+) {}

--- a/closet/src/main/java/com/codeit/closet/module/dm/mapper/DirectMessageMapper.java
+++ b/closet/src/main/java/com/codeit/closet/module/dm/mapper/DirectMessageMapper.java
@@ -1,0 +1,24 @@
+package com.codeit.closet.module.dm.mapper;
+
+import com.codeit.closet.module.dm.dto.DirectMessageDTO;
+import com.codeit.closet.module.dm.entity.DirectMessage;
+import com.codeit.closet.module.user.dto.user.UserSummary;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface DirectMessageMapper {
+
+    default DirectMessageDTO toDirectMessageDTO(
+            DirectMessage dm,
+            UserSummary sender,
+            UserSummary receiver
+    ) {
+        return new DirectMessageDTO(
+                dm.getId(),
+                dm.getCreatedAt(),
+                sender,
+                receiver,
+                dm.getContent()
+        );
+    }
+}

--- a/closet/src/main/java/com/codeit/closet/module/dm/service/DirectMessageService.java
+++ b/closet/src/main/java/com/codeit/closet/module/dm/service/DirectMessageService.java
@@ -1,11 +1,12 @@
 package com.codeit.closet.module.dm.service;
 
+import com.codeit.closet.module.dm.dto.DirectMessageDTO;
 import com.codeit.closet.module.dm.dto.DirectMessageDTOCursorResponse;
 
 import java.util.UUID;
 
 public interface DirectMessageService {
-    DirectMessageDTOCursorResponse createDirectMessage(UUID senderId, UUID receiverId, String content);
+    DirectMessageDTO create(UUID senderId, UUID receiverId, String content);
 
-    DirectMessageDTOCursorResponse getDirectMessages(UUID myUserId, UUID userId, String cursor, UUID idAfter, int limit);
+    DirectMessageDTOCursorResponse findDirectMessages(UUID myUserId, UUID userId, String cursor, UUID idAfter, int limit);
 }

--- a/closet/src/main/java/com/codeit/closet/module/dm/service/impl/BasicDirectMessageService.java
+++ b/closet/src/main/java/com/codeit/closet/module/dm/service/impl/BasicDirectMessageService.java
@@ -31,6 +31,12 @@ public class BasicDirectMessageService implements DirectMessageService {
     @Transactional
     public DirectMessageDTO create(UUID senderId, UUID receiverId, String content) {
         log.info("[Service] DM 저장 api 호출");
+
+        User sender = userRepository.findById(senderId)
+                .orElseThrow(() -> new IllegalArgumentException("sender not found"));
+        User receiver = userRepository.findById(receiverId)
+                .orElseThrow(() -> new IllegalArgumentException("receiver not found"));
+
         String dmKey = DmKeyUtil.of(senderId, receiverId);
 
         DirectMessage directMessage = DirectMessage.builder()
@@ -41,11 +47,6 @@ public class BasicDirectMessageService implements DirectMessageService {
                 .build();
 
         directMessageRepository.save(directMessage);
-
-        User sender = userRepository.findById(senderId)
-                .orElseThrow(() -> new IllegalArgumentException("송신자 찾을 수 없음"));
-        User receiver = userRepository.findById(receiverId)
-                .orElseThrow(() -> new IllegalArgumentException("수신자 찾을 수 없음"));
 
         UserSummary senderSummary = userMapper.toUserSummary(sender);
         UserSummary receiverSummary = userMapper.toUserSummary(receiver);

--- a/closet/src/main/java/com/codeit/closet/module/dm/service/impl/BasicDirectMessageService.java
+++ b/closet/src/main/java/com/codeit/closet/module/dm/service/impl/BasicDirectMessageService.java
@@ -1,28 +1,65 @@
 package com.codeit.closet.module.dm.service.impl;
 
+import com.codeit.closet.module.dm.dto.DirectMessageDTO;
 import com.codeit.closet.module.dm.dto.DirectMessageDTOCursorResponse;
+import com.codeit.closet.module.dm.entity.DirectMessage;
+import com.codeit.closet.module.dm.mapper.DirectMessageMapper;
 import com.codeit.closet.module.dm.repository.DirectMessageRepository;
 import com.codeit.closet.module.dm.service.DirectMessageService;
+import com.codeit.closet.module.dm.util.DmKeyUtil;
+import com.codeit.closet.module.user.dto.user.UserSummary;
+import com.codeit.closet.module.user.entity.User;
+import com.codeit.closet.module.user.mapper.UserMapper;
+import com.codeit.closet.module.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class BasicDirectMessageService implements DirectMessageService {
     private final DirectMessageRepository directMessageRepository;
+    private final DirectMessageMapper directMessageMapper;
+    private final UserRepository userRepository;
+    private final UserMapper userMapper;
 
     @Override
     @Transactional
-    public DirectMessageDTOCursorResponse createDirectMessage(UUID senderId, UUID receiverId, String content) {
-        return null;
+    public DirectMessageDTO create(UUID senderId, UUID receiverId, String content) {
+        log.info("[Service] DM 저장 api 호출");
+        String dmKey = DmKeyUtil.of(senderId, receiverId);
+
+        DirectMessage directMessage = DirectMessage.builder()
+                .dmKey(dmKey)
+                .senderId(senderId)
+                .receiverId(receiverId)
+                .content(content)
+                .build();
+
+        directMessageRepository.save(directMessage);
+
+        User sender = userRepository.findById(senderId)
+                .orElseThrow(() -> new IllegalArgumentException("송신자 찾을 수 없음"));
+        User receiver = userRepository.findById(receiverId)
+                .orElseThrow(() -> new IllegalArgumentException("수신자 찾을 수 없음"));
+
+        UserSummary senderSummary = userMapper.toUserSummary(sender);
+        UserSummary receiverSummary = userMapper.toUserSummary(receiver);
+
+        log.info("[Service] sender:{} receiver:{}", senderId, receiverId);
+
+        return directMessageMapper.toDirectMessageDTO(
+                directMessage, senderSummary, receiverSummary
+        );
     }
 
     @Override
     @Transactional(readOnly = true)
-    public DirectMessageDTOCursorResponse getDirectMessages(UUID myUserId, UUID userId, String cursor, UUID idAfter, int limit) {
+    public DirectMessageDTOCursorResponse findDirectMessages(UUID myUserId, UUID userId, String cursor, UUID idAfter, int limit) {
         return null;
     }
 }

--- a/closet/src/main/java/com/codeit/closet/module/user/mapper/UserMapper.java
+++ b/closet/src/main/java/com/codeit/closet/module/user/mapper/UserMapper.java
@@ -2,6 +2,7 @@ package com.codeit.closet.module.user.mapper;
 
 import com.codeit.closet.module.user.dto.profile.ProfileDTO;
 import com.codeit.closet.module.user.dto.user.UserDTO;
+import com.codeit.closet.module.user.dto.user.UserSummary;
 import com.codeit.closet.module.user.entity.User;
 import org.mapstruct.Mapper;
 
@@ -12,4 +13,14 @@ public interface UserMapper {
 
     // 차후에 LocationDTO랑 맵핑 해야함.
     ProfileDTO toProfileDTO(User user);
+
+    default UserSummary toUserSummary(User user) {
+        if (user == null) return null;
+        return new UserSummary(
+                user.getId(),
+                user.getName(),
+                "url"
+//                user.getBinaryContent().getFileUrl() //binaryContent 연결 후 사용
+        );
+    }
 }


### PR DESCRIPTION
## 📎 Issue 번호
- closed #51

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 📋 작업 내용 상세
- [x] DirectMessageMapper 추가
- [x] UserMapper에 UserSummary 변환 코드 추가
- [x] DM 저장 로직 작동 확인
<img width="2106" height="784" alt="image" src="https://github.com/user-attachments/assets/657afc04-3920-437a-b305-91e06ecef835" />


## 📄 작업 내용 요약

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **리팩토링**
  * 다이렉트 메시지 생성 API가 요청 본문(body) 기반으로 간소화되었습니다.
  * 메시지 조회 내부 호출 이름이 변경되어 내부 구조가 정리되었습니다.
* **신규 기능**
  * 메시지 생성 시 생성된 메시지 객체(DirectMessageDTO)를 바로 반환하도록 개선했습니다.
  * 사용자 요약 정보 변환이 추가되어 전송자/수신자 정보 표시가 일관되게 제공됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->