### PR TITLE
fix: Kakao 로그인 에러 해결

### DIFF
--- a/closet/src/main/java/com/codeit/closet/common/oauth/CustomOAuth2UserService.java
+++ b/closet/src/main/java/com/codeit/closet/common/oauth/CustomOAuth2UserService.java
@@ -47,6 +47,8 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
       }
 
       attributeKey = "kakao_account";
+    } else {
+      throw new OAuth2AuthenticationException("지원하지 않는 OAuth2 제공자 입니다! : " + registrationId);
     }
 
     String finalEmail = email;

--- a/closet/src/main/java/com/codeit/closet/common/oauth/CustomOAuth2UserService.java
+++ b/closet/src/main/java/com/codeit/closet/common/oauth/CustomOAuth2UserService.java
@@ -6,6 +6,7 @@ import com.codeit.closet.module.user.repository.UserRepository;
 import java.util.Collections;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
@@ -16,6 +17,7 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
@@ -31,28 +33,37 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     String registrationId = userRequest.getClientRegistration().getRegistrationId();
     OAuth2UserInfo userInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(registrationId,
         oauth2User.getAttributes());
-
     String email = userInfo.getEmail();
     String name = userInfo.getName();
     String providerId = userInfo.getId();
     AuthProvider provider = AuthProvider.valueOf(registrationId.toUpperCase());
 
-    // 카카오 로그인 처리
-    if (email == null) {
-      email = name + "_" + providerId + "@kakao.com";
+    log.info("email ={}, name = {}, providerId = {}, registrationId = {}", email, name, providerId, registrationId);
+    String attributeKey = null;
+
+    if (registrationId.equals("google")) {
+      attributeKey = "email";
+
+    } else if (registrationId.equals("kakao")) {
+      if (email == null) {
+        email = name + "_" + providerId + "@kakao.com";
+      }
+
+      attributeKey = "kakao_account";
     }
 
     String finalEmail = email;
-
     User user = userRepository.findByEmail(email)
         .map(existingUser -> updateProviderIfNeeded(existingUser, provider, providerId))
         .orElseGet(() -> createSocialUser(finalEmail, name, provider, providerId));
 
+
     return new DefaultOAuth2User(
         Collections.singleton(new SimpleGrantedAuthority("ROLE_" + user.getRole().name())),
         oauth2User.getAttributes(),
-        "email"
+        attributeKey
     );
+
   }
 
   @Transactional

--- a/closet/src/main/java/com/codeit/closet/common/oauth/CustomOAuth2UserService.java
+++ b/closet/src/main/java/com/codeit/closet/common/oauth/CustomOAuth2UserService.java
@@ -6,7 +6,6 @@ import com.codeit.closet.module.user.repository.UserRepository;
 import java.util.Collections;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
@@ -17,7 +16,6 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
@@ -38,7 +36,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     String providerId = userInfo.getId();
     AuthProvider provider = AuthProvider.valueOf(registrationId.toUpperCase());
 
-    log.info("email ={}, name = {}, providerId = {}, registrationId = {}", email, name, providerId, registrationId);
     String attributeKey = null;
 
     if (registrationId.equals("google")) {

--- a/closet/src/main/java/com/codeit/closet/common/oauth/OAuth2SuccessHandler.java
+++ b/closet/src/main/java/com/codeit/closet/common/oauth/OAuth2SuccessHandler.java
@@ -23,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -65,6 +66,8 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         providerId = String.valueOf(idObj);
       }
 
+    } else {
+      throw new OAuth2AuthenticationException("지원하지 않는 OAuth2 제공자 입니다: " + registrationId);
     }
     if (email == null && providerId == null) {
       response.setStatus(HttpServletResponse.SC_BAD_REQUEST);

--- a/closet/src/main/java/com/codeit/closet/common/oauth/OAuth2SuccessHandler.java
+++ b/closet/src/main/java/com/codeit/closet/common/oauth/OAuth2SuccessHandler.java
@@ -2,7 +2,6 @@ package com.codeit.closet.common.oauth;
 
 import com.codeit.closet.common.exception.ErrorResponse;
 import com.codeit.closet.common.security.ClosetUserDetails;
-import com.codeit.closet.common.security.jwt.JwtDTO;
 import com.codeit.closet.common.security.jwt.JwtInformation;
 import com.codeit.closet.common.security.jwt.JwtRegistry;
 import com.codeit.closet.common.security.jwt.JwtTokenProvider;
@@ -19,10 +18,10 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -40,6 +39,8 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
   private final ObjectMapper objectMapper;
   private final UserMapper userMapper;
 
+  @Value("${closet.base_url.redirect}")
+  private String base_url;
 
   @Override
   public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -88,7 +89,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
       refreshTokenCookie.setPath("/");
       response.addCookie(refreshTokenCookie);
 
-      response.sendRedirect("http://localhost:8080");
+      response.sendRedirect(base_url);
       response.setStatus(HttpServletResponse.SC_OK);
 
       jwtRegistry.registerJwtInformation(

--- a/closet/src/main/java/com/codeit/closet/common/oauth/OAuth2SuccessHandler.java
+++ b/closet/src/main/java/com/codeit/closet/common/oauth/OAuth2SuccessHandler.java
@@ -17,11 +17,14 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -45,10 +48,34 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
     response.setContentType("application/json");
 
     OAuth2User oauth2User = (OAuth2User) authentication.getPrincipal();
-    String email = oauth2User.getAttribute("email");
+    String registrationId = ((OAuth2AuthenticationToken) authentication).getAuthorizedClientRegistrationId();
+    String email = null;
+    String providerId = null;
 
-    User user = userRepository.findByEmail(email).orElseThrow(
-        () -> new NoSuchElementException("존재하지 않는 회원입니다."));
+    if ("google".equals(registrationId)) {
+      email = oauth2User.getAttribute("email");
+      providerId = oauth2User.getAttribute("sub");   // Google 고유 ID
+    }
+    else if ("kakao".equals(registrationId)) {
+    Map<String, Object> kakaoAccount = oauth2User.getAttribute("kakao_account");
+
+    if (kakaoAccount != null) {
+      email = (String) kakaoAccount.get("email"); // 카카오 이메일
+    }
+      providerId = String.valueOf((Long) oauth2User.getAttribute("id"));
+
+    }
+
+    User user;
+
+    if (email != null) {
+      user = userRepository.findByEmail(email).orElseThrow(
+          () -> new NoSuchElementException("존재하지 않는 회원입니다."));
+    } else {
+      user = userRepository.findByProviderId(providerId).orElseThrow(
+          () -> new NoSuchElementException("존재하지 않는 회원입니다."));
+    }
+
 
     UserDTO userDTO = userMapper.toUserDTO(user);
     ClosetUserDetails closetUserDetails = new ClosetUserDetails(userDTO, null, null, null);

--- a/closet/src/main/java/com/codeit/closet/common/oauth/OAuth2SuccessHandler.java
+++ b/closet/src/main/java/com/codeit/closet/common/oauth/OAuth2SuccessHandler.java
@@ -20,7 +20,6 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
@@ -28,7 +27,6 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
@@ -56,15 +54,25 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
     if ("google".equals(registrationId)) {
       email = oauth2User.getAttribute("email");
       providerId = oauth2User.getAttribute("sub");   // Google 고유 ID
-    }
-    else if ("kakao".equals(registrationId)) {
-    Map<String, Object> kakaoAccount = oauth2User.getAttribute("kakao_account");
+    } else if ("kakao".equals(registrationId)) {
+      Map<String, Object> kakaoAccount = oauth2User.getAttribute("kakao_account");
 
-    if (kakaoAccount != null) {
-      email = (String) kakaoAccount.get("email"); // 카카오 이메일
-    }
-      providerId = String.valueOf((Long) oauth2User.getAttribute("id"));
+      if (kakaoAccount != null) {
+        email = (String) kakaoAccount.get("email"); // 카카오 이메일
+      }
+      Object idObj = oauth2User.getAttribute("id");
+      if (idObj != null) {
+        providerId = String.valueOf(idObj);
+      }
 
+    }
+    if (email == null && providerId == null) {
+      response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+      ErrorResponse errorResponse = new ErrorResponse(
+          new NoSuchElementException("사용자 식별 정보를 가져올 수 없습니다."),
+          HttpServletResponse.SC_BAD_REQUEST);
+      response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+      return;
     }
 
     User user;
@@ -76,7 +84,6 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
       user = userRepository.findByProviderId(providerId).orElseThrow(
           () -> new NoSuchElementException("존재하지 않는 회원입니다."));
     }
-
 
     UserDTO userDTO = userMapper.toUserDTO(user);
     ClosetUserDetails closetUserDetails = new ClosetUserDetails(userDTO, null, null, null);
@@ -94,7 +101,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
       jwtRegistry.registerJwtInformation(
           new JwtInformation(closetUserDetails.getUserDTO(), accessToken, refreshToken));
-    }catch (JOSEException e) {
+    } catch (JOSEException e) {
       response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
       ErrorResponse errorResponse = new ErrorResponse(e,
           HttpServletResponse.SC_INTERNAL_SERVER_ERROR);

--- a/closet/src/main/java/com/codeit/closet/module/auth/controller/AuthController.java
+++ b/closet/src/main/java/com/codeit/closet/module/auth/controller/AuthController.java
@@ -30,8 +30,6 @@ public class AuthController {
 
   @GetMapping("/csrf-token")
   public ResponseEntity<Void> getCsrfToken(CsrfToken csrfToken) {
-    String token = csrfToken.getToken();
-    log.info("csrfToken: {}", token);
 
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
@@ -40,7 +38,6 @@ public class AuthController {
   public ResponseEntity<JwtDTO> createRefreshToken(
       @CookieValue(JwtTokenProvider.REFRESH_TOKEN_COOKIE_NAME) String refreshToken,
       HttpServletResponse response) {
-    log.info("Refresh Token: {}", refreshToken);
     JwtInformation jwtInformation = authService.refreshToken(refreshToken);
     Cookie cookie = jwtTokenProvider.generateRefreshTokenCookie(jwtInformation.getRefreshToken());
     response.addCookie(cookie);

--- a/closet/src/main/java/com/codeit/closet/module/user/repository/UserRepository.java
+++ b/closet/src/main/java/com/codeit/closet/module/user/repository/UserRepository.java
@@ -16,6 +16,8 @@ public interface UserRepository extends JpaRepository<User, UUID>, UserQueryRepo
 
   Optional<User> findByEmail(String email);
 
+  Optional<User> findByProviderId(String providerId);
+
   @Transactional
   @Modifying(clearAutomatically = true)
   @Query("UPDATE User u SET u.tempPassword = NULL, u.tempPasswordExpiredAt = NULL WHERE u.id = :userId")

--- a/closet/src/main/resources/application.yml
+++ b/closet/src/main/resources/application.yml
@@ -99,6 +99,8 @@ closet:
       service-key: ${KMA_SERVICE_KEY:dummyKey}
       timeout: 10000
       data-type: JSON
+  base_url:
+    redirect: ${DEPLOY_URL:http://localhost:8080}
 
 logging:
   level:

--- a/closet/src/main/resources/application.yml
+++ b/closet/src/main/resources/application.yml
@@ -64,6 +64,7 @@ spring:
             client-id: ${KAKAO_CLIENT_ID:dummy}
             client-secret: ${KAKAO_CLIENT_SECRET:dummy}
             client-name: Kakao
+            client-authentication-method: client_secret_post
             redirect-uri: ${BASEURL:http://localhost:8080}/login/oauth2/code/kakao
             authorization-grant-type: authorization_code
             scope:
@@ -95,7 +96,7 @@ closet:
   weather:
     api:
       base-url: http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0
-      service-key: ${KMA_SERVICE_KEY}
+      service-key: ${KMA_SERVICE_KEY:dummyKey}
       timeout: 10000
       data-type: JSON
 


### PR DESCRIPTION
## 📎 Issue 번호
- closed #95

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 📋 작업 내용 상세
- [x] yml 변경하여 OAuth2 Kakao 로그인 성공
- [x] OAuth2 Kakao, Google 구분해서 로그인 로직 구현

## 📄 작업 내용 요약

로그인 요청 -> CustomOAuth2UserService으로 아이디 생성 -> 아이디 생성 후 OAuth2SuccessHandler 토큰 발급 ->
redirect 사용해서 로그인 완료

<img width="1495" height="824" alt="{AC955347-5AE3-40CE-B863-518404ABA03D}" src="https://github.com/user-attachments/assets/11b2b88c-2627-416e-97f7-02ba5305ce46" />

Kakao 보여주고싶은데 일단 잘됨

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * OAuth2 로그인 개선: 구글·카카오에 대해 이메일 또는 공급자 ID를 기반으로 한 인증/연동 지원 확대
  * 인증 성공 후 리다이렉트 기본 URL을 환경에 따라 동적으로 설정하도록 추가

* **Bug Fixes**
  * 로그에서 민감 정보 출력 제거로 보안 강화
  * 카카오 로그인 시 이메일이 없을 경우의 식별자 처리 안정화

* **Chores**
  * 카카오 인증 설정 및 일부 기본 구성값(외부 API 키 기본값, 리다이렉트 기본값) 추가/조정

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->