### PR TITLE
[BUG] DM 저장 로직 관련 CSRF 설정 수정

### DIFF
--- a/closet/src/main/java/com/codeit/closet/common/config/SecurityConfig.java
+++ b/closet/src/main/java/com/codeit/closet/common/config/SecurityConfig.java
@@ -70,9 +70,9 @@ public class SecurityConfig {
         )
 
         .logout(logout -> logout
-                .logoutUrl("/api/auth/sign-out")
-                .addLogoutHandler(jwtLogoutHandler)
-                .logoutSuccessHandler(new HttpStatusReturningLogoutSuccessHandler()))
+                  .logoutUrl("/api/auth/sign-out")
+                  .addLogoutHandler(jwtLogoutHandler)
+                  .logoutSuccessHandler(new HttpStatusReturningLogoutSuccessHandler()))
 
         // CSRF 사용용 설정
         .csrf(csrf -> csrf

--- a/closet/src/main/java/com/codeit/closet/common/config/SecurityConfig.java
+++ b/closet/src/main/java/com/codeit/closet/common/config/SecurityConfig.java
@@ -69,13 +69,9 @@ public class SecurityConfig {
             .successHandler(oAuth2SuccessHandler)
         )
 
-        .logout(logout -> logout
-            .logoutUrl("/api/auth/sign-out")
-            .addLogoutHandler(jwtLogoutHandler)
-            .logoutSuccessHandler(new HttpStatusReturningLogoutSuccessHandler()))
-
         // CSRF 사용용 설정
         .csrf(csrf -> csrf
+            .ignoringRequestMatchers("/api/direct-messages/**") // dm 저장 요청
             .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
             .csrfTokenRequestHandler(new SpaCsrfTokenRequestHandler()))
 

--- a/closet/src/main/java/com/codeit/closet/common/config/SecurityConfig.java
+++ b/closet/src/main/java/com/codeit/closet/common/config/SecurityConfig.java
@@ -70,9 +70,9 @@ public class SecurityConfig {
         )
 
         .logout(logout -> logout
-                  .logoutUrl("/api/auth/sign-out")
-                  .addLogoutHandler(jwtLogoutHandler)
-                  .logoutSuccessHandler(new HttpStatusReturningLogoutSuccessHandler()))
+            .logoutUrl("/api/auth/sign-out")
+            .addLogoutHandler(jwtLogoutHandler)
+            .logoutSuccessHandler(new HttpStatusReturningLogoutSuccessHandler()))
 
         // CSRF 사용용 설정
         .csrf(csrf -> csrf

--- a/closet/src/main/java/com/codeit/closet/common/config/SecurityConfig.java
+++ b/closet/src/main/java/com/codeit/closet/common/config/SecurityConfig.java
@@ -69,6 +69,11 @@ public class SecurityConfig {
             .successHandler(oAuth2SuccessHandler)
         )
 
+        .logout(logout -> logout
+                .logoutUrl("/api/auth/sign-out")
+                .addLogoutHandler(jwtLogoutHandler)
+                .logoutSuccessHandler(new HttpStatusReturningLogoutSuccessHandler()))
+
         // CSRF 사용용 설정
         .csrf(csrf -> csrf
             .ignoringRequestMatchers("/api/direct-messages/**") // dm 저장 요청

--- a/closet/src/main/java/com/codeit/closet/module/dm/entity/DirectMessage.java
+++ b/closet/src/main/java/com/codeit/closet/module/dm/entity/DirectMessage.java
@@ -35,7 +35,13 @@ public class DirectMessage {
     @Column(columnDefinition ="TEXT", nullable = false)
     private String content;
 
-    @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;
+
+    @PrePersist
+    private void prePersist() {
+        if (this.createdAt == null) {
+            this.createdAt = Instant.now();
+        }
+    }
 }


### PR DESCRIPTION
## 📎 Issue 번호
- closed #103 

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 📋 작업 내용 상세
- [x] 저장api 호출 관련 csrf 설정 변경
- [x] createdAt 필드 어노테이션 @CreationTimestamp -> @PrePersist 수정 (CreationTimestamp는 insert 시점에서 생성 시간 결정되므로 dto로 변환되는 작업에서 null 오류 발생함. insert 시점 전에 생성 시간 결정되는 Prepersist로 변경)
<img width="400" height="860" alt="image" src="https://github.com/user-attachments/assets/df81b906-072f-456d-b3c9-7e9004f3aa2e" />

- ws 서버에도 pr 올렸고 채팅 기능 양쪽에서 잘 됩니다
+) 코드리뷰 반영 했습니다

## 📄 작업 내용 요약

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **보안 개선**
  * 직접 메시지 API에 CSRF 보호 강화

* **버그 수정**
  * 타임스탬프 초기화 로직 개선으로 데이터 일관성 증대

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->