### PR TITLE
[FEATURE] 의상 정보 JSOUP 웹 스크래핑 기능 구현

### DIFF
--- a/closet/build.gradle
+++ b/closet/build.gradle
@@ -86,6 +86,11 @@ dependencies {
     implementation 'software.amazon.awssdk:s3:2.31.7'
 
     /* =========================
+     * jsoup
+     * ========================= */
+    implementation 'org.jsoup:jsoup:1.17.2'
+
+    /* =========================
      * Dev
      * ========================= */
     implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'

--- a/closet/build.gradle
+++ b/closet/build.gradle
@@ -88,7 +88,7 @@ dependencies {
     /* =========================
      * jsoup
      * ========================= */
-    implementation 'org.jsoup:jsoup:1.17.2'
+    implementation 'org.jsoup:jsoup:1.22.1'
 
     /* =========================
      * Dev

--- a/closet/src/main/java/com/codeit/closet/module/cloth/controller/ClothController.java
+++ b/closet/src/main/java/com/codeit/closet/module/cloth/controller/ClothController.java
@@ -5,6 +5,7 @@ import com.codeit.closet.module.cloth.dto.ClothCreateRequest;
 import com.codeit.closet.module.cloth.dto.ClothDTO;
 import com.codeit.closet.module.cloth.dto.ClothDTOCursorResponse;
 import com.codeit.closet.module.cloth.dto.ClothUpdateRequest;
+import com.codeit.closet.module.cloth.service.ClothExtractionService;
 import com.codeit.closet.module.cloth.service.ClothService;
 import com.codeit.closet.module.user.entity.UserRole;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,7 @@ import java.util.UUID;
 public class ClothController {
 
     private final ClothService clothService;
+    private final ClothExtractionService clothExtractionService;
 
     // 옷 등록
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -88,5 +90,14 @@ public class ClothController {
         boolean isAdmin = userDetails.getUserDTO().role() == UserRole.ADMIN;
         clothService.deleteCloth(clothId, userDetails.getUserDTO().id(), isAdmin);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    // 구매 링크로 옷 정보 불러오기
+    @GetMapping("/extractions")
+    public ResponseEntity<ClothDTO> getClothesExtractions(
+            @RequestParam("url") String url
+    ){
+        ClothDTO result = clothExtractionService.extract(url);
+        return ResponseEntity.ok(result);
     }
 }

--- a/closet/src/main/java/com/codeit/closet/module/cloth/dto/ClothExtractionResult.java
+++ b/closet/src/main/java/com/codeit/closet/module/cloth/dto/ClothExtractionResult.java
@@ -1,0 +1,7 @@
+package com.codeit.closet.module.cloth.dto;
+
+public record ClothExtractionResult(
+        String name,
+        String imageUrl
+) {
+}

--- a/closet/src/main/java/com/codeit/closet/module/cloth/service/ClothExtractionService.java
+++ b/closet/src/main/java/com/codeit/closet/module/cloth/service/ClothExtractionService.java
@@ -1,0 +1,8 @@
+package com.codeit.closet.module.cloth.service;
+
+import com.codeit.closet.module.cloth.dto.ClothDTO;
+
+public interface ClothExtractionService {
+
+    ClothDTO extract(String rawUrl);
+}

--- a/closet/src/main/java/com/codeit/closet/module/cloth/service/impl/ClothExtractionServiceImpl.java
+++ b/closet/src/main/java/com/codeit/closet/module/cloth/service/impl/ClothExtractionServiceImpl.java
@@ -61,9 +61,7 @@ public class ClothExtractionServiceImpl implements ClothExtractionService {
                 name = doc.title();
             }
 
-            if (imageUrl.isBlank()) {
-                throw new IllegalArgumentException("대표 이미지(og:image) 추출 실패");
-            }
+            imageUrl = filterImageUrl(imageUrl); // gif 차단
 
             return new ClothExtractionResult(name, imageUrl);
         } catch (IOException e) {
@@ -98,5 +96,19 @@ public class ClothExtractionServiceImpl implements ClothExtractionService {
                 || host.endsWith(".zigzag.kr")
                 || host.endsWith(".musinsa.com")
                 || host.endsWith(".29cm.co.kr");
+    }
+
+    private String filterImageUrl(String imageUrl) {
+        if (imageUrl == null || imageUrl.isBlank()) {
+            return null;
+        }
+
+        String lower = imageUrl.toLowerCase();
+
+        if (lower.endsWith(".gif")) {
+            return null;
+        }
+
+        return imageUrl; // jpg/png/webp 허용
     }
 }

--- a/closet/src/main/java/com/codeit/closet/module/cloth/service/impl/ClothExtractionServiceImpl.java
+++ b/closet/src/main/java/com/codeit/closet/module/cloth/service/impl/ClothExtractionServiceImpl.java
@@ -78,7 +78,12 @@ public class ClothExtractionServiceImpl implements ClothExtractionService {
 
     private URI toUri(String url) {
         try {
-            return URI.create(url);
+            URI uri = URI.create(url);
+            String scheme = uri.getScheme();
+            if (scheme == null || (!scheme.equalsIgnoreCase("http") && !scheme.equalsIgnoreCase("https"))) {
+                throw new IllegalArgumentException("http 또는 https URL만 지원합니다.");
+                }
+            return uri;
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException("올바르지 않은 URL 형식입니다.");
         }

--- a/closet/src/main/java/com/codeit/closet/module/cloth/service/impl/ClothExtractionServiceImpl.java
+++ b/closet/src/main/java/com/codeit/closet/module/cloth/service/impl/ClothExtractionServiceImpl.java
@@ -1,0 +1,102 @@
+package com.codeit.closet.module.cloth.service.impl;
+
+import com.codeit.closet.module.cloth.dto.ClothDTO;
+import com.codeit.closet.module.cloth.dto.ClothExtractionResult;
+import com.codeit.closet.module.cloth.service.ClothExtractionService;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Set;
+
+@Service
+public class ClothExtractionServiceImpl implements ClothExtractionService {
+
+    // 지원 도메인 목록
+    private static final Set<String> ALLOWED_HOSTS = Set.of(
+            "zigzag.kr",
+            "www.musinsa.com",
+            "29cm.co.kr"
+    );
+
+    @Override
+    public ClothDTO extract(String rawUrl) {
+        String url = validateAndTrim(rawUrl);
+        URI uri = toUri(url);
+        String host = normalizeHost(uri.getHost());
+
+        if (!isAllowedHost(host)) { // 지원 도메인 체크
+            throw new IllegalArgumentException("지원하지 않는 사이트입니다. : " + host);
+        }
+
+        ClothExtractionResult r = extractOgMeta(url);
+
+        return new ClothDTO(
+                null,
+                null,
+                r.name(),
+                r.imageUrl(),
+                null,
+                null
+        );
+    }
+
+    private ClothExtractionResult extractOgMeta(String url) {
+        try {
+            Document doc = Jsoup.connect(url)
+                    .userAgent("Mozilla/5.0")
+                    .referrer("https://www.google.com")
+                    .timeout(5000)
+                    .get();
+
+            String name = doc.select("meta[property=og:title]")
+                    .attr("content");
+
+            String imageUrl = doc.select("meta[property=og:image]")
+                    .attr("content");
+
+            if (name == null || name.isBlank()) {
+                name = doc.title();
+            }
+
+            if (imageUrl == null || imageUrl.isBlank()) {
+                throw new IllegalArgumentException("대표 이미지(og:image) 추출 실패");
+            }
+
+            return new ClothExtractionResult(name, imageUrl);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("URL 접근/파싱 실패", e);
+        }
+    }
+
+    private String validateAndTrim(String rawUrl) {
+        if (rawUrl == null || rawUrl.isBlank()) {
+            throw new IllegalArgumentException("url은 필수입니다.");
+        }
+        return rawUrl.trim();
+    }
+
+    private URI toUri(String url) {
+        try {
+            return URI.create(url);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("올바르지 않은 URL 형식입니다.");
+        }
+    }
+
+    private String normalizeHost(String host) {
+        if (host == null || host.isBlank()) {
+            throw new IllegalArgumentException("올바르지 않은 URL 형식입니다.");
+        }
+        return host.toLowerCase();
+    }
+
+    private boolean isAllowedHost(String host) {
+        return ALLOWED_HOSTS.contains(host)
+                || host.endsWith(".zigzag.kr")
+                || host.endsWith(".musinsa.com")
+                || host.endsWith(".29cm.co.kr");
+    }
+}

--- a/closet/src/main/java/com/codeit/closet/module/cloth/service/impl/ClothExtractionServiceImpl.java
+++ b/closet/src/main/java/com/codeit/closet/module/cloth/service/impl/ClothExtractionServiceImpl.java
@@ -57,11 +57,11 @@ public class ClothExtractionServiceImpl implements ClothExtractionService {
             String imageUrl = doc.select("meta[property=og:image]")
                     .attr("content");
 
-            if (name == null || name.isBlank()) {
+            if (name.isBlank()) {
                 name = doc.title();
             }
 
-            if (imageUrl == null || imageUrl.isBlank()) {
+            if (imageUrl.isBlank()) {
                 throw new IllegalArgumentException("대표 이미지(og:image) 추출 실패");
             }
 


### PR DESCRIPTION
## 📎 Issue 번호
- closed #121 

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 📋 작업 내용 상세
- [x] 웹 페이지의 OG 태그(사진이나 제목 등이 미리보기로 저장된 데이터) 이용하여 웹 스크래핑함
- [x] 요구사항에 맞게 무신사/29cm/지그재그 사이트 허용해두었습니다 (잘 불러와짐)
- [x] gif인 경우 [413 Content Too Large] 오류로 저장이 안되므로 gif 파일은 사전에 null로 필터링
<img width="400" height="1065" alt="image" src="https://github.com/user-attachments/assets/7fc1c291-37a7-43f8-b84e-a2131498c323" />

+) 다른 사이트 url 넣으면 '지원하지 않는 사이트입니다.' 오류 발생 (프로토타입과 동일)
## 📄 작업 내용 요약

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 웹 URL에서 의류 이름과 이미지를 추출하는 새 API 엔드포인트 추가
  * 추출 결과를 반환하는 새로운 데이터 형식(ClothExtractionResult) 및 추출 서비스 인터페이스/구현 추가
  * Open Graph 등 메타데이터를 활용해 제목 및 이미지 자동 추출, GIF 이미지는 제외

* **품질/안정성**
  * 요청 URL의 호스트 검증 및 입력 유효성 검사, 오류 처리 강화

* **Chores**
  * HTML 메타데이터 파싱을 위한 jsoup 라이브러리 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->